### PR TITLE
update apiversion on ingresses

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: opendistro-elasticsearch
 home: https://github.com/navikt/opendistro-elasticsearch
-version: 0.3
+version: 0.4
 description: Open Distro for Elasticsearch
 sources:
   - https://github.com/navikt/opendistro-elasticsearch

--- a/templates/odfe-analyzer-ingress.yaml
+++ b/templates/odfe-analyzer-ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress -}}
 {{- $host := printf "%s-analyzer.%s" (include "fullname" .) .Values.ingress.domain -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}-analyzer

--- a/templates/odfe-ingress.yaml
+++ b/templates/odfe-ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress -}}
 {{- $host := printf "%s.%s" (include "fullname" .) .Values.ingress.domain -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}

--- a/templates/odfe-kibana-ingress.yaml
+++ b/templates/odfe-kibana-ingress.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.kibana.enabled .Values.ingress -}}
 {{- $serviceName := printf "%s-kibana" (include "fullname" .) -}}
 {{- $host := printf "%s.%s" $serviceName .Values.ingress.domain -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}-kibana


### PR DESCRIPTION
`extensions/v1beta1` is deprecated and will be removed in kubernetes 1.20. `networking.k8s.io/v1beta1` supported from 1.14.